### PR TITLE
chore: bump deps

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -49,4 +49,4 @@ export function run() {
   env.run();
 }
 
-export { expect, mock } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+export { expect, mock } from "https://deno.land/x/expect@v0.2.9/mod.ts";

--- a/src/nodes_util.ts
+++ b/src/nodes_util.ts
@@ -1,5 +1,5 @@
 import { DescribeNode, ItNode, RootNode } from "./nodes.ts";
-import { bold, gray } from "https://deno.land/std@0.95.0/fmt/colors.ts";
+import { bold, gray } from "https://deno.land/std@0.97.0/fmt/colors.ts";
 
 type FindChildResult = ItNode | DescribeNode | undefined;
 

--- a/src/reporters.ts
+++ b/src/reporters.ts
@@ -1,5 +1,5 @@
 import { DescribeNode, Hook, ItNode, RootNode } from "./nodes.ts";
-import { gray, red } from "https://deno.land/std@0.95.0/fmt/colors.ts";
+import { gray, red } from "https://deno.land/std@0.97.0/fmt/colors.ts";
 
 export type TestReporter = {
   reportStart: (node: RootNode) => void;

--- a/tests/environment_test.ts
+++ b/tests/environment_test.ts
@@ -16,7 +16,7 @@ Environment
 
 import { Environment } from "../src/environment.ts";
 import { SilentReporter, silentTest } from "./test_util.ts";
-import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+import { expect } from "https://deno.land/x/expect@v0.2.9/mod.ts";
 
 function noop() {}
 

--- a/tests/mod_test.ts
+++ b/tests/mod_test.ts
@@ -7,7 +7,7 @@ import {
   it,
   run,
 } from "../src/mod.ts";
-import { expect, mock } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+import { expect, mock } from "https://deno.land/x/expect@v0.2.9/mod.ts";
 
 function noop() {}
 

--- a/tests/nodes_test.ts
+++ b/tests/nodes_test.ts
@@ -35,7 +35,7 @@ node.finish()
 
 */
 
-import { expect, mock } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+import { expect, mock } from "https://deno.land/x/expect@v0.2.9/mod.ts";
 import { DescribeNode, ItNode, RootNode, Tree } from "../src/nodes.ts";
 
 function noop() {}

--- a/tests/nodes_util_test.ts
+++ b/tests/nodes_util_test.ts
@@ -17,7 +17,7 @@ import {
   findChildWithLastCase,
   getAncestry,
 } from "../src/nodes_util.ts";
-import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+import { expect } from "https://deno.land/x/expect@v0.2.9/mod.ts";
 
 function noop() {}
 

--- a/tests/runner_test.ts
+++ b/tests/runner_test.ts
@@ -14,7 +14,7 @@ Runner.runNode
 
 */
 
-import { expect, mock } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+import { expect, mock } from "https://deno.land/x/expect@v0.2.9/mod.ts";
 import { Runner } from "../src/runner.ts";
 import { Hook, RootNode, Tree } from "../src/nodes.ts";
 import { SilentReporter, silentTest } from "./test_util.ts";


### PR DESCRIPTION
This PR bumps all deps to latest, including `expect`. Before it was causing weird `unstable` APIs errors due to old std version. With the latest version it runs fine.